### PR TITLE
Swap dependency from eframe to egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,13 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-eframe = "0.20.1"
+egui = "0.20.1"
 
 [dev-dependencies]
 egui_extras = "0.20.0"
 color-hex = "0.2.0"
 egui = { version = "0.20.1", features = ["color-hex"] }
+eframe = "0.20.1"
 
 
 [workspace]

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
-use eframe::egui;
-use eframe::egui::{CursorIcon, Id, InnerResponse, LayerId, Order, Pos2, Rect, Sense, Ui, Vec2};
+use egui;
+use egui::{CursorIcon, Id, InnerResponse, LayerId, Order, Pos2, Rect, Sense, Ui, Vec2};
 use std::hash::Hash;
 
 use crate::utils::shift_vec;


### PR DESCRIPTION
`eframe` is a constrictive dependency to have - a lot of projects use `egui` without `eframe`. Since this crate doesn't depend on any of the features in `eframe`, it makes sense to change it.

I've not tested these changes beyond ensuring they compile, though I see no reason why this should break anything.