### PR TITLE
Improve the shift_vec function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,12 @@ mod state;
 
 /// Helper functions to support the drag and drop functionality
 pub mod utils {
-    /// Move an element from one index to another in a vector, shifting the other elements as
-    /// needed.
+    /// Move an item in a slice according to the drag and drop logic.
+    ///
+    /// Rotates the section of the slice between `source_idx` and `target_idx` such that the item
+    /// previously at `source_idx` ends up at `target_idx - 1` if `target_idx > source_idx`, and
+    /// at `target_idx` otherwhise. This matches the expected behavior when grabbing the item in
+    /// the UI and moving it to another position.
     ///
     /// # Example
     ///
@@ -16,26 +20,34 @@ pub mod utils {
     /// use egui_dnd::utils::shift_vec;
     ///
     /// let mut v = vec![1, 2, 3, 4];
+    /// shift_vec(1, 1, &mut v);
+    /// assert_eq!(v, [1, 2, 3, 4]);
     /// shift_vec(0, 2, &mut v);
-    /// assert_eq!(v, [2, 1, 3, 4])
+    /// assert_eq!(v, [2, 1, 3, 4]);
+    /// shift_vec(2, 0, &mut v);
+    /// assert_eq!(v, [3, 2, 1, 4]);
     /// ```
     ///
     /// # Panics
-    /// Panics if `source_idx` >= len() or `target_idx` > len()
+    /// Panics if `source_idx >= len()` or `target_idx > len()`
     /// ```rust,should_panic
     /// use egui_dnd::utils::shift_vec;
     ///
     /// let mut v = vec![1];
     /// shift_vec(0, 2, &mut v);
     /// ```
-    pub fn shift_vec<T>(source_idx: usize, target_idx: usize, vec: &mut Vec<T>) {
-        let target_idx = if source_idx >= target_idx {
-            target_idx
+    pub fn shift_vec<T>(source_idx: usize, target_idx: usize, vec: &mut [T]) {
+        if let Some(slice) = vec.get_mut(source_idx..target_idx) {
+            slice.rotate_left(1.min(slice.len()));
+        } else if let Some(slice) = vec.get_mut(target_idx..=source_idx) {
+            slice.rotate_right(1.min(slice.len()));
         } else {
-            target_idx - 1
-        };
-
-        let item = vec.remove(source_idx);
-        vec.insert(target_idx, item);
+            panic!(
+                "Failed to move item from index {} to index {}. Slice has {} elements",
+                source_idx,
+                target_idx,
+                vec.len()
+            );
+        }
     }
 }


### PR DESCRIPTION
- Simplified the logic and made it more idiomatic by using the rotate methods that are meant for this.
- Made the panic case more explicit. It is still the same panic as before, but now it can be easily removed if we prefer to just ignore invalid arguments.
- Allowed it to accept any slice, not just Vec.